### PR TITLE
added information regarding required python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Information regarding Python version needed
+This library was built using Python 2.x .
+For this particular branch to work, you need python 2.x installed. Kindly follow this post (https://stackoverflow.com/a/62037932/23378869) to create a python 2.7.18 virtual environment and install this library in the virtual environment if you wish not to disturb your existing python 3.x environment.
+
+ Migration to python 3.xx is a good a good idea and will be considered in absence of other alternatives.
+
+# **Usage**
 # android-qfil-unsparse
 Tool to reassemble the sparse images used by Qualcomm Flash Image Loader
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 This library was built using Python 2.x .
 For this particular branch to work, you need python 2.x installed. Kindly follow this post (https://stackoverflow.com/a/62037932/23378869) to create a python 2.7.18 virtual environment and install this library in the virtual environment if you wish not to disturb your existing python 3.x environment.
 
- Migration to python 3.xx is a good a good idea and will be considered in absence of other alternatives.
-
 # **Usage**
 # android-qfil-unsparse
 Tool to reassemble the sparse images used by Qualcomm Flash Image Loader


### PR DESCRIPTION
This is a wonderful library and is supposed to work with python 2.7.xx I didn't know it initially and after encountering errors I discovered a syntax unfamiliar to me in the print statements.

It would be helpful for new python3 users like me to learn how to make use of legacy scripts. 

Adding this information to the documentation should help.